### PR TITLE
Improve custom-storage, use InjectionToken

### DIFF
--- a/projects/example/src/app/grid.directive.component.html
+++ b/projects/example/src/app/grid.directive.component.html
@@ -1,5 +1,5 @@
-<kendo-grid [expandedRows]="expandedRows" (stateReady)="onGotState($event)" [gridState]="'ANiceGrid'"
-  [storage]="storage" #grid [data]="data$ | async" [pageable]="{
+<kendo-grid [expandedRows]="expandedRows" (stateReady)="onGotState($event)" [gridState]="'ANiceGrid'" #grid
+  [data]="data$ | async" [pageable]="{
     buttonCount: 5,
     info: true,
     type: 'numeric',

--- a/projects/example/src/app/grid.directive.component.ts
+++ b/projects/example/src/app/grid.directive.component.ts
@@ -7,13 +7,17 @@ import {
 import { State, toODataString, groupBy } from "@progress/kendo-data-query";
 import { map } from "rxjs/operators";
 import { AppService } from "./app.service";
-import { IGridStateStorage } from "projects/kendo-grid-state/src/public-api";
+import { GRID_STATE_STORAGE, IGridStateStorage } from "projects/kendo-grid-state/src/public-api";
 
+// This is a sample implementation of IGridStateStorage which internally uses LocalStorage.
+// To read/write grid state e.g. to a database you will have to implement your own logic.
 class CustomGridStateStorage implements IGridStateStorage {
   getItem(key: string): string {
+    console.log(`CustomGridStateStorage.getItem: key='${key}'`);
     return localStorage.getItem(key);
   }
   setItem(key: string, value: string): void {
+    console.log(`CustomGridStateStorage.setItem: key='${key}', value='${value}'`);
     localStorage.setItem(key, value);
   }
 }
@@ -21,6 +25,8 @@ class CustomGridStateStorage implements IGridStateStorage {
 @Component({
   selector: "gridDirectiveCompoment",
   templateUrl: "./grid.directive.component.html",
+  // To use the default storage (Session) remove the providers section
+  providers: [{ provide: GRID_STATE_STORAGE, useClass: CustomGridStateStorage }]
 })
 export class GridDirectiveComponent implements OnInit {
   title: string = "example grid";
@@ -28,7 +34,6 @@ export class GridDirectiveComponent implements OnInit {
   gridState: State = { skip: 0, take: 10, group: [{ field: "SupplierID" }] };
   expandedRows: any[] = [];
   data$: Observable<GridDataResult>;
-  storage: IGridStateStorage = new CustomGridStateStorage();
   constructor(private service: AppService) { }
   onGotState = (e: DataStateChangeEvent): void => {
     this.onStateChange(e);

--- a/projects/kendo-grid-state/src/lib/GridStateModule.ts
+++ b/projects/kendo-grid-state/src/lib/GridStateModule.ts
@@ -1,9 +1,11 @@
 import { NgModule } from "@angular/core";
 import { GridStateDirective } from "./GridStateDirective";
+import { GridStateSessionStorage, GRID_STATE_STORAGE } from "./GridStateStorage";
 
 @NgModule({
   imports: [],
   declarations: [GridStateDirective],
   exports: [GridStateDirective],
+  providers: [{ provide: GRID_STATE_STORAGE, useClass: GridStateSessionStorage }]
 })
-export class GridStateModule {}
+export class GridStateModule { }

--- a/projects/kendo-grid-state/src/lib/GridStateStorage.ts
+++ b/projects/kendo-grid-state/src/lib/GridStateStorage.ts
@@ -1,4 +1,26 @@
+import { InjectionToken } from "@angular/core";
+
+export const GRID_STATE_STORAGE = new InjectionToken("GRID_STATE_STORAGE");
+
 export interface IGridStateStorage {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
+}
+
+export class GridStateLocalStorage implements IGridStateStorage {
+  public getItem(key: string): string {
+    return localStorage.getItem(key);
+  }
+  setItem(key: string, value: string): void {
+    localStorage.setItem(key, value);
+  }
+}
+
+export class GridStateSessionStorage implements IGridStateStorage {
+  public getItem(key: string): string {
+    return sessionStorage.getItem(key);
+  }
+  setItem(key: string, value: string): void {
+    sessionStorage.setItem(key, value);
+  }
 }


### PR DESCRIPTION
Dear Lynden,
after discussing the current implementation of custom-storage with a colleague I decided to make it more angular-like by using an InjectionToken. The default storage is still SessionStorage. I also updated the example to show how to override the storage.